### PR TITLE
Fix bug preventing running without threads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,6 @@ fn interactive(args: Cli, user_hz: f64) -> Result<()> {
         print_proc_metrics(metrics, descriptions);
 
         sampler.sample(sample_duration)?;
-        clear_n_lines(args.pids.len() + 1);
+        clear_n_lines(sampler.buffers().count() + 1);
     }
 }


### PR DESCRIPTION
Threads were added in the sample step irrespective of the boolean flag. This commit fixes it.
It also adjusts the interactive mode to take threads into account.